### PR TITLE
check for lib in postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/FormidableLabs/victory-voronoi",
   "scripts": {
-    "postinstall": "npm run build-lib",
+    "postinstall": "node -e \"require('fs').stat('lib', function(e,s){process.exit(e || !s.isDirectory() ? 1 : 0)})\" || npm run build-lib",
     "preversion": "npm run check",
     "version": "npm run clean && npm run build && git add -A dist",
     "clean-dist": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "homepage": "https://github.com/FormidableLabs/victory-voronoi",
   "scripts": {
-    "postinstall": "node -e \"require('fs').stat('lib', function(e,s){process.exit(e || !s.isDirectory() ? 1 : 0)})\" || npm run build-lib",
+    "postinstall": "cd lib || npm run build-lib",
     "preversion": "npm run check",
     "version": "npm run clean && npm run build && git add -A dist",
     "clean-dist": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "webpack": "^1.10.0"
   },
   "devDependencies": {
-    "babel-eslint": "^3.1.25",
+    "babel-eslint": "^5.0.0",
     "chai": "^3.2.0",
     "eslint": "^0.24.1",
     "eslint-config-defaults": "^3.0.3",


### PR DESCRIPTION
cc/ @coopy 

npm install fails the first time with a particular combination of node + npm versions. This implements the fix we've been using on other victory repos.

closes https://github.com/FormidableLabs/builder/issues/24

More detail here:
FormidableLabs/formidable-react-component-boilerplate#49
